### PR TITLE
ci: add JSON validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download the JSON schema
-        run: wget https://raw.githubusercontent.com/ossf/osv-schema/main/validation/schema.json
+        run: wget https://raw.githubusercontent.com/ossf/osv-schema/v1.6.0/validation/schema.json
 
       - name: Validate JSON
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,19 @@
+name: JSON Schema Validation
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download the JSON schema
+        run: wget https://raw.githubusercontent.com/ossf/osv-schema/main/validation/schema.json
+
+      - name: Validate JSON
+        run: |
+          pip install check-jsonschema
+          check-jsonschema --schemafile schema.json upstream/*.json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,4 +17,4 @@ jobs:
         run: pip install check-jsonschema
 
       - name: Validate JSON
-        run: check-jsonschema --schemafile schema.json upstream/*.json
+        run: check-jsonschema --schemafile schema.json $(git diff --name-only HEAD main | grep .json)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Download the JSON schema
         run: wget https://raw.githubusercontent.com/ossf/osv-schema/v1.6.0/validation/schema.json
 
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
       - name: Validate JSON
-        run: |
-          pip install check-jsonschema
-          check-jsonschema --schemafile schema.json upstream/*.json
+        run: check-jsonschema --schemafile schema.json upstream/*.json


### PR DESCRIPTION
Validate JSON advisories against [the JSON schema](https://github.com/ossf/osv-schema/tree/main/validation). The version is fixed to v1.6.0 so that the test result will be consistent. Otherwise, re-triggering the test leads to a different result.